### PR TITLE
Drupal 9 compatibility fixes c/- upgrade_status

### DIFF
--- a/islandora_fits.info.yml
+++ b/islandora_fits.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Fits'
 type: module
 description: 'Enables Technical Metadata derivative generation'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - islandora

--- a/tests/src/Functional/LoadTest.php
+++ b/tests/src/Functional/LoadTest.php
@@ -29,6 +29,11 @@ class LoadTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp() {
     parent::setUp();
     $this->user = $this->drupalCreateUser(['administer site configuration']);


### PR DESCRIPTION
* Declare module compatible with Drupal 9 in `islandora_fits.info.yml`
* Specify default theme for test in `tests/src/Functional/LoadTest.php` per https://www.drupal.org/node/3083055