### PR TITLE
Remove unnecessary field permissions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
     "source": "http://cgit.drupalcode.org/islandora_fits"
   },
   "require": {
-    "ext-SimpleXML": "*",
+    "ext-SimpleXML": "*"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,5 @@
   },
   "require": {
     "ext-SimpleXML": "*",
-    "drupal/field_permissions": "^1.1"
   }
 }

--- a/config/install/field.storage.media.field_complete.yml
+++ b/config/install/field.storage.media.field_complete.yml
@@ -7,9 +7,6 @@ dependencies:
   enforced:
     module:
       - islandora_fits
-third_party_settings:
-  field_permissions:
-    permission_type: public
 id: media.field_complete
 field_name: field_complete
 entity_type: media

--- a/islandora_fits.info.yml
+++ b/islandora_fits.info.yml
@@ -6,4 +6,3 @@ core_version_requirement: ^8 || ^9
 package: 'Islandora'
 dependencies:
   - islandora
-  - field_permissions


### PR DESCRIPTION
There's a module dependency that does absolutely nothing. We have this module configuring a field to have field permissions set to public, and we require the field permissions module to do that.
This PR removes this config and dependency.