### PR TITLE
Remove attach_library call in twig template

### DIFF
--- a/templates/fits.html.twig
+++ b/templates/fits.html.twig
@@ -1,6 +1,3 @@
-{{ attach_library('css/islandora_fits') }}
-
-
 <h1>{{ title }}</h1>
 <p>{{ link }}</p>
 


### PR DESCRIPTION
See issue #19 

If we still need the attach_library call in the template let me know and I'll change this PR.