### PR TITLE
Declare Drupal 11 compatibility

### DIFF
--- a/islandora_fits.info.yml
+++ b/islandora_fits.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Fits'
 type: module
 description: 'Enables Technical Metadata derivative generation'
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: 'Islandora'
 dependencies:
   - islandora:islandora

--- a/src/Plugin/Field/FieldFormatter/FitsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FitsFormatter.php
@@ -8,7 +8,6 @@ use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\file\Entity\File;
 use Drupal\Core\Link;
-use Drupal\Core\Url;
 
 /**
  * Plugin implementation of the 'fits_formatter' formatter.
@@ -81,7 +80,7 @@ class FitsFormatter extends FormatterBase {
     $link = $link->toRenderable();
     $contents = file_get_contents($file->getFileUri());
     if (mb_detect_encoding($contents) != 'UTF-8') {
-      $contents = utf8_encode($contents);
+      $contents = mb_convert_encoding($contents, 'UTF-8', mb_list_encodings());
     }
     $output = $transformer->transformFits($contents);
     $output['#link'] = $link;

--- a/src/Services/XMLTransform.php
+++ b/src/Services/XMLTransform.php
@@ -5,16 +5,14 @@ namespace Drupal\islandora_fits\Services;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\DependencyInjection\ServiceProviderBase;
 use Drupal\Core\Entity\EntityFieldManager;
-use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\media\MediaInterface;
-use DrupalCodeGenerator\Command\Drupal_8\Form\Simple;
 
 /**
- * Class XMLTransform.
+ * Transform FITS XML.
  */
 class XMLTransform extends ServiceProviderBase {
   /**
@@ -71,7 +69,7 @@ class XMLTransform extends ServiceProviderBase {
   public function transformFits($input_xml) {
     $utf8 = mb_detect_encoding($input_xml, 'UTF-8', TRUE);
     if (!$utf8) {
-      $input_xml = utf8_encode($input_xml);
+      $input_xml = mb_convert_encoding($input_xml, 'UTF-8', mb_list_encodings());
     }
     try {
       $xml = new \SimpleXMLElement($input_xml);
@@ -163,7 +161,7 @@ class XMLTransform extends ServiceProviderBase {
    *
    * Once it has these it passes them off recursively.
    *
-   * @param  \SimpleXMLElement
+   * @param \SimpleXMLElement $xml
    *   The SimpleXMLElement to parse.
    *
    * @return array


### PR DESCRIPTION
Also, ran php code sniffer on the codebase, which detected that `utf8_encode` is deprecated. So replaced it https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated#utf8_encode-any-mbstring

@ajstanley